### PR TITLE
value indicating message comes from remote node

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,5 +1,6 @@
 export interface IPaymentResult {
     success: boolean;
+    isRemoteMessage: boolean;
     message: string;
 }
 export declare enum ErrorReason {

--- a/dist/index.js
+++ b/dist/index.js
@@ -383,12 +383,14 @@ function handleLNURL(lnurl, invoice, proxy) {
             if (status === 'ERROR') {
                 return {
                     success: false,
+                    isRemoteMessage: true,
                     message: reason,
                 };
             }
             if (!callback || typeof callback !== 'string' || !k1 || typeof k1 !== 'string') {
                 return {
                     success: false,
+                    isRemoteMessage: false,
                     message: 'invalid response',
                 };
             }
@@ -397,6 +399,7 @@ function handleLNURL(lnurl, invoice, proxy) {
         catch (e) {
             return {
                 success: false,
+                isRemoteMessage: false,
                 message: e instanceof Error ? e.message : 'Unhandled error handling lnurl',
             };
         }
@@ -432,23 +435,27 @@ function handlePayment(callback, k1, invoice, proxy) {
             if (paymentResult.status === 'OK') {
                 return {
                     success: true,
+                    isRemoteMessage: false,
                     message: 'invoice payment initiated',
                 };
             }
             if (paymentResult.status === 'ERROR') {
                 return {
                     success: false,
+                    isRemoteMessage: true,
                     message: paymentResult.reason,
                 };
             }
             return {
                 success: false,
+                isRemoteMessage: false,
                 message: 'invalid response',
             };
         }
         catch (e) {
             return {
                 success: false,
+                isRemoteMessage: false,
                 message: e instanceof Error ? e.message : 'Unhandled error handling payment',
             };
         }

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -13,11 +13,14 @@ lnurlReader.onLnurlRead = async (lnurl) => {
 
     // Call the lnurlw flow
     const invoice = (document.getElementById('invoice') as HTMLInputElement)!.value;
-    const result = await handleLNURL(lnurl, invoice, '/proxy');
+
+    // NOTE: It's better to pass a proxy with this call, because otherwise you'll run into CORS issues
+    // if the client's responses do not return the proper CORS headers.
+    const result = await handleLNURL(lnurl, invoice);
     if (result.success) {
       log('lnurlw flow succeeded. Invoice should be paid shortly.');
     } else {
-      log(`lnurlw flow failed. Reason: '${result.message}'`);
+      log(`lnurlw flow failed. Reason from ${result.isRemoteMessage ? 'remote' : 'local'}: '${result.message}'`);
     }
   } catch (e: unknown) {
     // Handle errors you caused in the code above (inside try)

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { bech32 } from 'bech32';
 
 export interface IPaymentResult {
   success: boolean;
+  isRemoteMessage: boolean;
   message: string;
 }
 
@@ -437,6 +438,7 @@ export async function handleLNURL(
     if (status === 'ERROR') {
       return {
         success: false,
+        isRemoteMessage: true,
         message: reason,
       };
     }
@@ -444,6 +446,7 @@ export async function handleLNURL(
     if (!callback || typeof callback !== 'string' || !k1 || typeof k1 !== 'string') {
       return {
         success: false,
+        isRemoteMessage: false,
         message: 'invalid response',
       };
     }
@@ -452,6 +455,7 @@ export async function handleLNURL(
   } catch (e: unknown) {
     return {
       success: false,
+      isRemoteMessage: false,
       message: e instanceof Error ? e.message : 'Unhandled error handling lnurl',
     };
   }
@@ -496,6 +500,7 @@ export async function handlePayment(
     if (paymentResult.status === 'OK') {
       return {
         success: true,
+        isRemoteMessage: false,
         message: 'invoice payment initiated',
       };
     }
@@ -503,17 +508,20 @@ export async function handlePayment(
     if (paymentResult.status === 'ERROR') {
       return {
         success: false,
+        isRemoteMessage: true,
         message: paymentResult.reason,
       };
     }
 
     return {
       success: false,
+      isRemoteMessage: false,
       message: 'invalid response',
     };
   } catch (e: unknown) {
     return {
       success: false,
+      isRemoteMessage: false,
       message: e instanceof Error ? e.message : 'Unhandled error handling payment',
     };
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -767,7 +767,7 @@ describe('handleLnurl', () => {
   test('Should return success false if fetch rejects', async () => {
     fetchMock.mockRejectedValue(new Error('oops'));
     const result = await handleLNURL(url, invoice, proxyUrl);
-    expect(result).toStrictEqual({ success: false, message: 'oops' });
+    expect(result).toStrictEqual({ success: false, isRemoteMessage: false, message: 'oops' });
   });
 
   test('Should return success false if json rejects', async () => {
@@ -775,7 +775,7 @@ describe('handleLnurl', () => {
       json: jest.fn().mockRejectedValue(new Error('oops')),
     });
     const result = await handleLNURL(url, invoice, proxyUrl);
-    expect(result).toStrictEqual({ success: false, message: 'oops' });
+    expect(result).toStrictEqual({ success: false, isRemoteMessage: false, message: 'oops' });
   });
 
   test('Should return success false if json is not according to spec', async () => {
@@ -783,7 +783,7 @@ describe('handleLnurl', () => {
       json: jest.fn().mockResolvedValue({ something: 'else' }),
     });
     const result = await handleLNURL(url, invoice, proxyUrl);
-    expect(result).toStrictEqual({ success: false, message: 'invalid response' });
+    expect(result).toStrictEqual({ success: false, isRemoteMessage: false, message: 'invalid response' });
   });
 
   test('Should return success false if status error is returned', async () => {
@@ -791,7 +791,7 @@ describe('handleLnurl', () => {
       json: jest.fn().mockResolvedValue({ status: 'ERROR', reason: 'oops' }),
     });
     const result = await handleLNURL(url, invoice, proxyUrl);
-    expect(result).toStrictEqual({ success: false, message: 'oops' });
+    expect(result).toStrictEqual({ success: false, isRemoteMessage: true, message: 'oops' });
   });
 
   test('Should return success false if status error is returned without reason', async () => {
@@ -799,7 +799,7 @@ describe('handleLnurl', () => {
       json: jest.fn().mockResolvedValue({ status: 'ERROR' }),
     });
     const result = await handleLNURL(url, invoice, proxyUrl);
-    expect(result).toStrictEqual({ success: false, message: undefined });
+    expect(result).toStrictEqual({ success: false, isRemoteMessage: true, message: undefined });
   });
 
   test('Should return success false if status OK but no callback', async () => {
@@ -807,7 +807,7 @@ describe('handleLnurl', () => {
       json: jest.fn().mockResolvedValue({ status: 'OK', k1: '1234' }),
     });
     const result = await handleLNURL(url, invoice, proxyUrl);
-    expect(result).toStrictEqual({ success: false, message: 'invalid response' });
+    expect(result).toStrictEqual({ success: false, isRemoteMessage: false, message: 'invalid response' });
   });
 
   test('Should return success false if status OK but no k1', async () => {
@@ -815,7 +815,7 @@ describe('handleLnurl', () => {
       json: jest.fn().mockResolvedValue({ status: 'OK', callback: 'https://callback' }),
     });
     const result = await handleLNURL(url, invoice, proxyUrl);
-    expect(result).toStrictEqual({ success: false, message: 'invalid response' });
+    expect(result).toStrictEqual({ success: false, isRemoteMessage: false, message: 'invalid response' });
   });
 
   test('Should call the right url when callback without querystring and no proxy', async () => {
@@ -900,7 +900,7 @@ describe('handleLnurl', () => {
       })
       .mockRejectedValueOnce(new Error('oops'));
     const result = await handleLNURL(url, invoice, proxyUrl);
-    expect(result).toStrictEqual({ success: false, message: 'oops' });
+    expect(result).toStrictEqual({ success: false, isRemoteMessage: false, message: 'oops' });
   });
 
   test('Should return success false if second fetch json throws', async () => {
@@ -914,7 +914,7 @@ describe('handleLnurl', () => {
         json: jest.fn().mockRejectedValue(new Error('oops')),
       });
     const result = await handleLNURL(url, invoice, proxyUrl);
-    expect(result).toStrictEqual({ success: false, message: 'oops' });
+    expect(result).toStrictEqual({ success: false, isRemoteMessage: false, message: 'oops' });
   });
 
   test('Should return success false if second response invalid', async () => {
@@ -928,7 +928,7 @@ describe('handleLnurl', () => {
         json: jest.fn().mockResolvedValue({ something: 'else' }),
       });
     const result = await handleLNURL(url, invoice, proxyUrl);
-    expect(result).toStrictEqual({ success: false, message: 'invalid response' });
+    expect(result).toStrictEqual({ success: false, isRemoteMessage: false, message: 'invalid response' });
   });
 
   test('Should return success false if second status is error', async () => {
@@ -942,7 +942,7 @@ describe('handleLnurl', () => {
         json: jest.fn().mockResolvedValue({ status: 'ERROR', reason: 'oops' }),
       });
     const result = await handleLNURL(url, invoice, proxyUrl);
-    expect(result).toStrictEqual({ success: false, message: 'oops' });
+    expect(result).toStrictEqual({ success: false, isRemoteMessage: true, message: 'oops' });
   });
 
   test('Should return success false if second status is error without reason', async () => {
@@ -956,7 +956,7 @@ describe('handleLnurl', () => {
         json: jest.fn().mockResolvedValue({ status: 'ERROR' }),
       });
     const result = await handleLNURL(url, invoice, proxyUrl);
-    expect(result).toStrictEqual({ success: false, message: undefined });
+    expect(result).toStrictEqual({ success: false, isRemoteMessage: true, message: undefined });
   });
 
   test('Should return success if second status OK', async () => {
@@ -970,6 +970,6 @@ describe('handleLnurl', () => {
         json: jest.fn().mockResolvedValue({ status: 'OK' }),
       });
     const result = await handleLNURL(url, invoice, proxyUrl);
-    expect(result).toStrictEqual({ success: true, message: 'invoice payment initiated' });
+    expect(result).toStrictEqual({ success: true, isRemoteMessage: false, message: 'invoice payment initiated' });
   });
 });


### PR DESCRIPTION
Add a boolean to indicate whether the error message comes from the remote node or is a local message.

If the message is local, that doesn't mean it's 'our' fault that a flow is not working. If the remote node returns invalid json for example, it's their fault, but the message is created by the local code.